### PR TITLE
fixed issue with no disconnect on connecting status, added tests

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -22,11 +22,8 @@ dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile 'com.android.support:appcompat-v7:21.0.3'
     compile 'io.reactivex:rxjava:1.0.3'
-    compile 'com.squareup.dagger:dagger:1.2.2'
-    compile 'com.squareup.dagger:dagger-compiler:1.2.2'
     compile 'com.google.android.gms:play-services-location:6.5.87'
 
     androidTestCompile 'com.google.dexmaker:dexmaker:1.1'
     androidTestCompile 'com.google.dexmaker:dexmaker-mockito:1.1'
-    androidTestCompile 'com.squareup.assertj:assertj-android:1.0.0'
 }

--- a/library/src/main/java/com/zmarkan/observablelocation/LocationUpdatesObservable.java
+++ b/library/src/main/java/com/zmarkan/observablelocation/LocationUpdatesObservable.java
@@ -86,10 +86,8 @@ public class LocationUpdatesObservable implements Observable.OnSubscribe<Locatio
         @Override
         public void call() {
             if (googleAPIClient.isConnected() || googleAPIClient.isConnecting()) {
-                if (googleAPIClient.isConnected()) {
-                    locationProviderAPI.removeLocationUpdates(googleAPIClient, locationListener);
-                    googleAPIClient.disconnect();
-                }
+                locationProviderAPI.removeLocationUpdates(googleAPIClient, locationListener);
+                googleAPIClient.disconnect();
             }
         }
     }


### PR DESCRIPTION
Updated code to disconnect when the API is in the connecting state, from the google api docs.
### public abstract void disconnect ()

Closes the connection to Google Play services. No calls can be made using this client after calling this method. Any method calls that haven't executed yet will be canceled. That is onResult(Result) won't be called, if connection to the service hasn't been established yet all calls already made will be canceled.
#### See Also
### connect()
